### PR TITLE
Fix metalsmith.join

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,7 @@ function plugin(opts){
         str = clone.contents;
         render = consolidate[engine].render;
       } else {
-        str = metalsmith.path(metalsmith.source(), dir, data.template || def);
+        str = metalsmith.path(dir, data.template || def);
         render = consolidate[engine];
       }
 


### PR DESCRIPTION
Looks like metalsmith got rid of the join method and replaced it with path. For some reason I had to append the source directory to it as well. This is my first time using metalsmith so that seems weird to me.
