### PR TITLE
fix EJS includes when inPlace is used

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -73,6 +73,7 @@ function plugin(opts){
       if (inPlace) {
         str = clone.contents;
         render = consolidate[engine].render;
+        clone.filename = file;
       } else {
         str = metalsmith.path(dir, data.template || def);
         render = consolidate[engine];


### PR DESCRIPTION
When inPlace is used, a different rendering function is used, one that does not set the `filename` attribute.
It causes EJS to fail on includes: `filename option is required for includes`.

This pull request fixes this bug by setting the `filename` attribute when inPlace is used.
