### PR TITLE
Adding documentation for how to use templates in content files

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,7 +28,8 @@
   "plugins": {
     "metalsmith-templates": {
       "engine": "handlebars",
-      "directory": "templates"
+      "directory": "templates",
+      "default": "layout.html"
     }
   }
 }
@@ -49,8 +50,32 @@ metalsmith.use(templates('swig'));
 ```js
 metalsmith.use(templates({
   engine: 'swig',
-  directory: 'templates'
+  directory: 'templates',
+  default: 'layout.html'
 }));
+```
+
+## File Usage
+
+  To render a template for a file, set its `template` property to the template's filename, either through its front-matter:
+
+```
+---
+template: layout.html
+---
+```
+
+  Or through a plugin:
+
+```js
+function () {
+  return function addTemplate (files, metalsmith, done) {
+    for (var file in files) {
+      files[file].template = 'layout.html';
+    }
+    done();
+  };
+}
 ```
 
 ## License


### PR DESCRIPTION
It seems obvious now, but I had to read [the source](https://github.com/segmentio/metalsmith-templates/blob/552c00f38975b8eb0cd7a49f9d2dc121fb905dbb/lib/index.js#L50) to discover that the `template` property is what controls the template for a given content file. I thought it would be a helpful detail to include in the readme.
