### PR TITLE
Throw an error for unsupported engines

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,6 +42,10 @@ function plugin(opts){
   var inPlace = opts.inPlace;
   var def = opts.default;
   var params = omit(opts, settings);
+  
+  if (!consolidate[engine]) {
+    throw new Error('Unknown template engine: "' + engine + '"');
+  }
 
   return function(files, metalsmith, done){
     var metadata = metalsmith.metadata();


### PR DESCRIPTION
Added error handling for unsupported `consolidate` engines, so that you don’t get a confusing stack trace if there’s a typo in the engine name.